### PR TITLE
fix: TransitionKeys are now precompiled before running diagnostics.

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -32,6 +32,8 @@ export function activate(context: vscode.ExtensionContext) {
 	// context.subscriptions.push(vscode.commands.registerCommand(command, formatDocument));
 
 	let languageServerRunning = ZSconfig.get<boolean>('serverStartupSetting', false); // Default to 2 if not set
+	let displayAlphaWarning = ZSconfig.get<boolean>('displayAlphaWarning', true);
+	let precompileTransitionKeys = ZSconfig.get<boolean>('precompileTransitionKeys', false);
 
 	context.subscriptions.push(vscode.commands.registerCommand('ZeroSyntax.stopLanguageServer', () => {
 		if (languageServerRunning) {
@@ -72,10 +74,12 @@ export function activate(context: vscode.ExtensionContext) {
 			// Notify the server about file changes to '.clientrc files contained in the workspace
 			fileEvents: vscode.workspace.createFileSystemWatcher('**/.clientrc')
 		},
-		// initializationOptions: {
+		initializationOptions: {
+			precompileTransitionKeys: precompileTransitionKeys,
+			forceAddModule: forceAddModule
 		// 	SemanticTokenTypes,
 		// 	SemanticTokenModifiers
-		// },
+		},
 		// middleware: {
         //     didChange: (event, next) => {
         //         const { contentChanges, document } = event;
@@ -104,7 +108,14 @@ export function activate(context: vscode.ExtensionContext) {
 		client.start();
 	}
 
-	vscode.window.showWarningMessage('Zero Syntax: This is an alpha version!\nPlease report bugs to https://github.com/ViTeXFTW/ZeroSyntax-Server/issues');
+	if (displayAlphaWarning) {
+		// Add buttons to close or turn off the warning
+		vscode.window.showWarningMessage('Zero Syntax: This is an alpha version!\nPlease report bugs to https://github.com/ViTeXFTW/ZeroSyntax-Server/issues', 'Turn off', 'Close').then((selection) => {
+			if (selection === 'Turn off') {
+				ZSconfig.update('displayAlphaWarning', false, vscode.ConfigurationTarget.Global);
+			}
+		});
+	}
 }
 
 vscode.workspace.onDidChangeConfiguration((e) => {

--- a/package.json
+++ b/package.json
@@ -82,13 +82,28 @@
 					"default": true,
 					"description": "Controls whether the server is started automatically after the extension is activated."
 				},
-				"languageServerExample.maxNumberOfProblems": {
+				"ZeroSyntax.displayAlphaWarning": {
+					"type": "boolean",
+					"default": true,
+					"description": "Controls whether the alpha warning is displayed when the server is started."
+				},
+				"ZeroSyntax.forceAddModule": {
+					"type": "boolean",
+					"default": true,
+					"description": "Controls whether AddModule around modules is forced."
+				},
+				"ZeroSyntax.precompileTransitionKeys": {
+					"type": "boolean",
+					"default": true,
+					"description": "Controls whether the transition keys are precompiled when the server is started."
+				},
+				"ZeroSyntax.maxNumberOfProblems": {
 					"scope": "resource",
 					"type": "number",
 					"default": 100,
 					"description": "Controls the maximum number of problems produced by the server."
 				},
-				"languageServerExample.trace.server": {
+				"ZeroSyntax.trace.server": {
 					"scope": "window",
 					"type": "string",
 					"enum": [
@@ -105,6 +120,7 @@
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
 		"package": "npm run compile && vsce package",
+		"cc": "npm run clean && npm run antlr4ng && npm run compile",
 		"compile": "tsc -b",
 		"clean": "rimraf ./client/out && rimraf ./server/out",
 		"compile-test": "cd client && npm run compile-test && cd .. && cd server && npm run compile-test",

--- a/server/src/parser.ts
+++ b/server/src/parser.ts
@@ -13,6 +13,8 @@ export class Parser {
     private lexer: MapIniLexer | undefined;
     private tokenStream: CommonTokenStream | undefined;
 
+    private document: TextDocument | undefined;
+
     constructor() {}
 
     updateParser(document: TextDocument): MapIniParser {
@@ -20,6 +22,7 @@ export class Parser {
         this.lexer = new MapIniLexer(this.inputStream);
         this.tokenStream = new CommonTokenStream(this.lexer);
         this.latestParser = new MapIniParser(this.tokenStream);
+        this.document = document;
 
         return this.latestParser
     }
@@ -46,6 +49,10 @@ export class Parser {
         } else {
             return null
         }
+    }
+
+    getDocument(): TextDocument | undefined {
+        return this.document
     }
 
 }


### PR DESCRIPTION
# Why
To fix error where `TransitionKeys` were displayed with errors even tho the code was valid.

# Changes
Updated package.json, extension.ts, server.ts to handle new settings.
Updated diagnosticVisitor.ts to handle look ahead for `TransitionKeys`

# Issues
Fixes: #24 